### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,8 +107,12 @@ function formatter(results) {
     msg += count.bold.yellow;
     return msg;
 }
-
+var _files = [];
 module.exports = function(content, file, conf) {
+  if(_files.indexOf(file.id) > -1){ //避免重复校验
+    return;
+  }
+  _files.push(file.id);
   var assign = require('mixin-deep');
   var defConf = require('./package.json').defconf;
   var globals = defConf.globals;


### PR DESCRIPTION
fis的文件遍历机制会出现文件重复遍历的问题，比如在html里面引入项目下js路径的index.js，那么在遍历时会把html引入的index.js遍历一次，然后再去遍历项目下的js文件，自然也就重复了idnex.js。
所以在做eslint校验时，会出现html引入的js以及项目下所有的js都会校验一次，会出现重复校验的可能性。本次修改是为了避免重复校验的问题。